### PR TITLE
Move top margin to the header

### DIFF
--- a/styles/term3.less
+++ b/styles/term3.less
@@ -41,8 +41,8 @@
 
 terminal-list-view {
   display: flex;
-  margin-top: 10px;
   .header {
+    margin-top: 10px;
     img {
       width: 22px;
       padding-right: 5px;


### PR DESCRIPTION
This PR moves the top margin to the `.header`. So that if Term3 is not open, it doesn't take up any space.

Fixes https://github.com/atom/one-dark-ui/issues/111

<img width="191" alt="screen shot 2015-11-25 at 14 39 48" src="https://cloud.githubusercontent.com/assets/11625453/11390374/745efc5e-9384-11e5-991b-5c94718176f0.png">

:warning: This only works if the `.header` is __always__ shown in the tree-view. Not sure if that's the case or if there are situations where there would be no `.header`.