### PR TITLE
added solid background option

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -94,6 +94,9 @@ config =
       foreground:
         type: 'color'
         default: '#f0f0f0'
+  backgroundSolid:
+    type: 'boolean'
+    default: true
   scrollback:
     type: 'integer'
     default: 1000
@@ -207,17 +210,18 @@ module.exports =
 
   createTermView: (forkPTY=true, rows=30, cols=80) ->
     opts =
-      runCommand    : atom.config.get 'term3.autoRunCommand'
-      shellOverride : atom.config.get 'term3.shellOverride'
-      shellArguments: atom.config.get 'term3.shellArguments'
-      titleTemplate : atom.config.get 'term3.titleTemplate'
-      cursorBlink   : atom.config.get 'term3.cursorBlink'
-      fontFamily    : atom.config.get 'term3.fontFamily'
-      fontSize      : atom.config.get 'term3.fontSize'
-      colors        : getColors()
-      forkPTY       : forkPTY
-      rows          : rows
-      cols          : cols
+      runCommand     : atom.config.get 'term3.autoRunCommand'
+      shellOverride  : atom.config.get 'term3.shellOverride'
+      shellArguments : atom.config.get 'term3.shellArguments'
+      titleTemplate  : atom.config.get 'term3.titleTemplate'
+      cursorBlink    : atom.config.get 'term3.cursorBlink'
+      backgroundSolid: atom.config.get 'term3.backgroundSolid'
+      fontFamily     : atom.config.get 'term3.fontFamily'
+      fontSize       : atom.config.get 'term3.fontSize'
+      colors         : getColors()
+      forkPTY        : forkPTY
+      rows           : rows
+      cols           : cols
 
     if opts.shellOverride
         opts.shell = opts.shellOverride

--- a/lib/term-view.coffee
+++ b/lib/term-view.coffee
@@ -169,8 +169,11 @@ class TermView extends View
     "terminal"
 
   applyStyle: ->
-    # remove background color in favor of the atom background
-    # @term.element.style.background = null
+    # remove background color in favor of the atom background if option the
+    # backgroundSolid option is not selected
+    if !@opts.backgroundSolid
+      @term.element.style.background = null
+
     @term.element.style.fontFamily = (
       @opts.fontFamily or
       atom.config.get('editor.fontFamily') or


### PR DESCRIPTION
I noticed that with [this commit](https://github.com/Floobits/atom-term3/commit/097b4ea2716cf360b18bfa5f5a42cdd47208b3aa) it was deleted the transparent background. I think that an option to select the background opacity can be useful.

N.B. the README still tells that the background is tranparent by default.
