### PR TITLE
Add activationCommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,14 @@
         "0.1.3": "service_0_1_3"
       }
     }
+  },
+  "activationCommands": {
+    "atom-workspace": [
+      "term3:open",
+      "term3:open-split-up",
+      "term3:open-split-right",
+      "term3:open-split-down",
+      "term3:open-split-left"
+    ]
   }
 }


### PR DESCRIPTION
The activation of term3 can take very long in comparison with other packages, and makes atom's startup slow, even when term3 is never used. Adding activationCommands defers the activation until one of these commands is used.